### PR TITLE
chore: exclude Claude context from public repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,7 @@ apiError
 .idea/
 .env*
 .DS_Store
+# ── Claude Code (public repo — internal context 노출 방지) ──
+.claude/
+CLAUDE.md
+claude-memory/


### PR DESCRIPTION
## Summary
- chore(gitignore): exclude `.claude/`, `CLAUDE.md`, `claude-memory/` (public repo 노출 방지)

## Test plan
- gitignore-only change. 빌드 영향 없음.

릴리스 새 태그 불필요 (functional change 아님).