### PR TITLE
docs(readme): note private dev context

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,8 @@ apiErrors that using across based on Cellularhacker's Codes written in Go.
   ```
 ## ※ Important
 - package name is just `apiError`. so you have to use like **`apiError.Error`**, not **`apiError-go.Error`.**
+
+
+## Development Notes
+
+Internal development context (design notes, work log, decisions) for this repo is maintained by the owner in a separate **private** repository — it is **not** required to use this library. Public consumers can ignore.


### PR DESCRIPTION
Adds a short paragraph saying internal dev notes live in a separate private repo. No functional change, no new release needed.